### PR TITLE
Fix ERR_INVALID_PACKAGE_TARGET

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A Fastify Piscina Plugin",
   "main": "./plugin.js",
   "exports": {
-    "import": ".esm-wrapper.mjs",
+    "import": "./esm-wrapper.mjs",
     "require": "./plugin.js"
   },
   "types": "./plugin.d.ts",


### PR DESCRIPTION
This fixes a bug when loaded as esm.
Invalid "exports" main target .esm-wrapper.mjs -targets must start with "./"