### PR TITLE
feat!: update plugin for fastify v5 and fix types

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,0 @@
-esm-wrapper.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [20.x, 22.x, 24.x]
     runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v3

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ profile-*
 # lock files
 package-lock.json
 yarn.lock
+pnpm-lock.yaml

--- a/esm-wrapper.mjs
+++ b/esm-wrapper.mjs
@@ -1,4 +1,0 @@
-import mod from "./plugin.js";
-
-export default mod;
-export const fastifyPiscina = mod.fastifyPiscina;

--- a/example/esm/server.mjs
+++ b/example/esm/server.mjs
@@ -1,5 +1,5 @@
 import { fastify } from 'fastify';
-import * as fastifyPiscina from '../../esm-wrapper.mjs';
+import * as fastifyPiscina from '../../plugin.js';
 
 const app = fastify({ logger: true });
 

--- a/package.json
+++ b/package.json
@@ -3,14 +3,13 @@
   "version": "5.0.0",
   "description": "A Fastify Piscina Plugin",
   "main": "./plugin.js",
+  "types": "./plugin.d.ts",
   "exports": {
-    "import": "./esm-wrapper.mjs",
+    "types": "./plugin.d.ts",
+    "import": "./plugin.js",
     "require": "./plugin.js"
   },
-  "types": "./plugin.d.ts",
   "scripts": {
-    "prepack": "npm run build",
-    "build": "gen-esm-wrapper . esm-wrapper.mjs",
     "lint": "standardx \"**/*.{mjs,js,cjs}\" | snazzy",
     "lint:fix": "standardx --fix",
     "test": "tap -J test/*.test.{js,mjs}",
@@ -35,17 +34,16 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^16.11.11",
-    "fastify": "^4.24.3",
-    "gen-esm-wrapper": "^1.1.3",
+    "@types/node": "^22.5.5",
+    "fastify": "^5.0.0",
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
     "tap": "^15.1.5",
     "tsd": "^0.19.0"
   },
   "dependencies": {
-    "fastify-plugin": "^4.5.1",
-    "piscina": "^4.2.0"
+    "fastify-plugin": "^5.0.0",
+    "piscina": "^4.7.0"
   },
   "eslintConfig": {
     "rules": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
     "tap": "^15.1.5",
-    "tsd": "^0.19.0"
+    "tsd": "^0.33.0"
   },
   "dependencies": {
     "fastify-plugin": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
   "standardx": {},
   "tsd": {
     "directory": "test/types"
+  },
+  "engines": {
+    "node": ">=20.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^22.5.5",
+    "@types/node": "^24.3.0",
     "fastify": "^5.0.0",
     "snazzy": "^9.0.0",
     "standardx": "^7.0.0",
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "fastify-plugin": "^5.0.0",
-    "piscina": "^4.7.0"
+    "piscina": "^5.1.3"
   },
   "eslintConfig": {
     "rules": {

--- a/plugin.d.ts
+++ b/plugin.d.ts
@@ -1,21 +1,26 @@
 import { FastifyPluginCallback } from 'fastify';
-import Piscina from 'piscina';
+import { Piscina } from 'piscina';
 
-type PiscinaOptions = typeof Piscina extends {
-  new (options?: infer T): Piscina;
-}
-  ? T
-  : never;
+type PiscinaOptions = NonNullable<ConstructorParameters<typeof Piscina>[0]>;
 
-export interface FastifyPiscinaPool extends Piscina {}
+type FastifyPiscinaPluginType = FastifyPluginCallback<PiscinaOptions>;
 
-// Most importantly, use declaration merging to add the custom property to the Fastify type system
 declare module 'fastify' {
   interface FastifyInstance {
-    piscina: FastifyPiscinaPool;
-    runTask: FastifyPiscinaPool['run'];
+    piscina: fastifyPiscina.FastifyPiscinaPool;
+    runTask: fastifyPiscina.FastifyPiscinaRunTask;
   }
 }
 
-declare const fastifyPiscina: FastifyPluginCallback<PiscinaOptions>;
-export default fastifyPiscina;
+declare namespace fastifyPiscina {
+  export type FastifyPiscinaPool = Piscina;
+  export type FastifyPiscinaRunTask = Piscina['run'];
+
+  export type FastifyPiscinaPluginOptions = PiscinaOptions;
+
+  export const fastifyPiscina: FastifyPiscinaPluginType;
+  export { fastifyPiscina as default };
+}
+
+declare function fastifyPiscina(...params: Parameters<FastifyPiscinaPluginType>): ReturnType<FastifyPiscinaPluginType>;
+export = fastifyPiscina;

--- a/plugin.js
+++ b/plugin.js
@@ -2,9 +2,9 @@
 
 const fp = require('fastify-plugin');
 const Piscina = require('piscina');
-const { name, version } = require('./package.json');
+const { name } = require('./package.json');
 
-function piscinaPlugin (fastify, options, next) {
+function fastifyPiscina (fastify, options, next) {
   if (fastify.piscina || fastify.runTask) {
     return next(new Error('fastify-piscina has already been registered'));
   }
@@ -17,8 +17,11 @@ function piscinaPlugin (fastify, options, next) {
   next();
 }
 
-module.exports = fp(piscinaPlugin, {
-  fastify: '>=4.0.0',
-  name,
-  version
+const plugin = fp(fastifyPiscina, {
+  fastify: '3.x',
+  name
 });
+
+module.exports = plugin;
+module.exports.default = plugin;
+module.exports.fastifyPiscina = plugin;

--- a/plugin.js
+++ b/plugin.js
@@ -18,7 +18,7 @@ function fastifyPiscina (fastify, options, next) {
 }
 
 const plugin = fp(fastifyPiscina, {
-  fastify: '3.x',
+  fastify: '5.x',
   name
 });
 

--- a/test/plugin-esm.test.mjs
+++ b/test/plugin-esm.test.mjs
@@ -2,7 +2,7 @@
 
 import { test } from 'tap';
 import Fastify from 'fastify';
-import fastifyPiscina from '../esm-wrapper.mjs';
+import fastifyPiscina from '../plugin.js';
 
 test('It should add decorators - ESM', async (t) => {
   t.plan(3);
@@ -29,9 +29,7 @@ test('It should throw when trying to register the plugin more than once - ESM', 
   t.plan(1);
 
   const fastify = Fastify();
-  fastify
-    .register(fastifyPiscina)
-    .register(fastifyPiscina);
+  fastify.register(fastifyPiscina).register(fastifyPiscina);
 
   fastify.ready((err) => {
     t.equal(err.message, 'fastify-piscina has already been registered');


### PR DESCRIPTION
Fixes #14 

Updated the plugin to support Fastify v5 while I was at it

Also removed the esm-wrapper, as it's no longer needed in recent Node.js versions