### PR TITLE
Update import name in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 const fastify = require('fastify')();
 const { resolve} = require('path');
 
-fastify.register(require('fastify-piscina'), {
+fastify.register(require('@piscina/fastify'), {
   // Piscina Options object. See Piscina docs for details
   filename: resolve(__dirname, 'worker.js')
 });


### PR DESCRIPTION
Looks like the package name change to a scoped package but the example was still pointing to the old package name.